### PR TITLE
patch in sorting of pivot level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-klass-python"
-version = "0.0.8"
+version = "0.0.9"
 description = "A Python package built on top of KLASS's API for retrieving classifications, codes, correspondences etc."
 authors = ["Carl Corneil, ssb-pythonistas <ssb-pythonistas@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
Recieved complaints that the sorting of levels has not yet been patched into Pypi, so this PR is just for bumping the version to cause a new version to push to Pypi.