### PR TITLE
Akseptere int som classification_id i typehint

### DIFF
--- a/src/klass/classes/classification.py
+++ b/src/klass/classes/classification.py
@@ -53,9 +53,9 @@ class KlassClassification:
         _links (dict): A dictionary containing the links to different possible endpoints using the classification.
 
     Args:
-        classification_id (str): The classification_id of the classification. For example: '36'
-        language (str): The language of the classification. "nb", "nn" or "en".
-        include_future (bool): Whether to include future versions of the classification.
+        classification_id: The classification_id of the classification. For example: '36'
+        language: The language of the classification. "nb", "nn" or "en".
+        include_future: Whether to include future versions of the classification.
 
     Raises:
         ValueError: If the language is not "no", "nb" or "en".
@@ -136,10 +136,10 @@ class KlassClassification:
         If no ID is specified, will get the first version under the attribute .versions on this class.
 
         Args:
-            version_id (int): The version ID of the version.
-            select_level (int): The level of the version to keep in the data.
-            language (str): The language of the version. "nn", "nb" or "en".
-            include_future (bool): Whether to include future versions of the version.
+            version_id: The version ID of the version.
+            select_level: The level of the version to keep in the data.
+            language: The language of the version. "nn", "nb" or "en".
+            include_future: Whether to include future versions of the version.
 
         Returns:
             KlassVersion: A KlassVersion object of the specified ID.
@@ -185,16 +185,16 @@ class KlassClassification:
         redefine upper levels for some lower-level codes.
 
         Args:
-            name (str): The start of the name of the variant.
-            from_date (str): The start date of the time period. "YYYY-MM-DD".
-            to_date (str): The end date of the time period. "YYYY-MM-DD".
-            select_codes (str): Limit the result to codes matching this pattern.
+            name: The start of the name of the variant.
+            from_date: The start date of the time period. "YYYY-MM-DD".
+            to_date: The end date of the time period. "YYYY-MM-DD".
+            select_codes: Limit the result to codes matching this pattern.
                 See rules: https://data.ssb.no/api/klass/v1/api-guide.html#_selectcodes.
-            select_level (int): The level of the version to keep in the data.
-            presentation_name_pattern (str): Used to build an alternative presentation name for the codes.
+            select_level: The level of the version to keep in the data.
+            presentation_name_pattern: Used to build an alternative presentation name for the codes.
                 See rules: https://data.ssb.no/api/klass/v1/api-guide.html#_presentationnamepattern.
-            language (str): The language of the version. "nn", "nb" or "en".
-            include_future (bool): Whether to include future versions of the version.
+            language: The language of the version. "nn", "nb" or "en".
+            include_future: Whether to include future versions of the version.
 
         Returns:
             KlassVariantSearchByName: A KlassVariantSearchByName object based on the classification's ID
@@ -225,11 +225,11 @@ class KlassClassification:
         Returns a KlassCorrespondence object of the correspondences.
 
         Args:
-            target_classification_id (str): The classification ID of the target classification.
-            from_date (str): The start date of the time period. "YYYY-MM-DD".
-            to_date (str): The end date of the time period. "YYYY-MM-DD".
-            language (str): The language of the correspondences. "nn", "nb" or "en".
-            include_future (bool): Whether to include future correspondences.
+            target_classification_id: The classification ID of the target classification.
+            from_date: The start date of the time period. "YYYY-MM-DD".
+            to_date: The end date of the time period. "YYYY-MM-DD".
+            language: The language of the correspondences. "nn", "nb" or "en".
+            include_future: Whether to include future correspondences.
 
         Returns:
             KlassCorrespondence: A KlassCorrespondence object of the correspondences
@@ -261,15 +261,15 @@ class KlassClassification:
         """Return a KlassCodes object of the classification at a specific time or in a specific time range.
 
         Args:
-            from_date (str): The start date of the time period. "YYYY-MM-DD".
-            to_date (str): The end date of the time period. "YYYY-MM-DD".
-            select_codes (str): Limit the result to codes matching this pattern.
+            from_date: The start date of the time period. "YYYY-MM-DD".
+            to_date: The end date of the time period. "YYYY-MM-DD".
+            select_codes: Limit the result to codes matching this pattern.
                 See rules: https://data.ssb.no/api/klass/v1/api-guide.html#_selectcodes.
-            select_level (int): The level of the version to keep in the data.
-            presentation_name_pattern (str): Used to build an alternative presentation name for the codes.
+            select_level: The level of the version to keep in the data.
+            presentation_name_pattern: Used to build an alternative presentation name for the codes.
                 See rules: https://data.ssb.no/api/klass/v1/api-guide.html#_presentationnamepattern.
-            language (str): The language of the version. "nn", "nb" or "en".
-            include_future (bool): Whether to include future versions of the version.
+            language: The language of the version. "nn", "nb" or "en".
+            include_future: Whether to include future versions of the version.
 
         Returns:
             KlassCodes: A KlassCodes object of the classification at a specific time or in a specific time range.
@@ -304,10 +304,10 @@ class KlassClassification:
         but only what has changed since the last update or within the time range.
 
         Args:
-            from_date (str): The start date of the time period. "YYYY-MM-DD".
-            to_date (str): The end date of the time period. "YYYY-MM-DD".
-            language (str): The language of the version. "nn", "nb" or "en".
-            include_future (bool): Whether to include future versions of the version.
+            from_date: The start date of the time period. "YYYY-MM-DD".
+            to_date: The end date of the time period. "YYYY-MM-DD".
+            language: The language of the version. "nn", "nb" or "en".
+            include_future: Whether to include future versions of the version.
 
         Returns:
             pd.DataFrame: A pandas DataFrame of the changes in the classification at a specific time

--- a/src/klass/classes/codes.py
+++ b/src/klass/classes/codes.py
@@ -21,14 +21,14 @@ class KlassCodes:
         to_date (str): The end date of the time period. "YYYY-MM-DD".
 
     Args:
-        classification_id (str): The classification ID.
-        from_date (str): The start date of the time period. "YYYY-MM-DD".
-        to_date (str): The end date of the time period. "YYYY-MM-DD".
-        select_codes (str): A list of codes to be selected.
-        select_level (int): The level to keep in the data.
-        presentation_name_pattern (str): A pattern for filtering the code names.
-        language (str): The language of the code names. Defaults to "nb".
-        include_future (bool): Whether to include future codes. Defaults to False.
+        classification_id: The classification ID.
+        from_date: The start date of the time period. "YYYY-MM-DD".
+        to_date: The end date of the time period. "YYYY-MM-DD".
+        select_codes: A list of codes to be selected.
+        select_level: The level to keep in the data.
+        presentation_name_pattern: A pattern for filtering the code names.
+        language: The language of the code names. Defaults to "nb".
+        include_future: Whether to include future codes. Defaults to False.
 
     Raises:
         ValueError: If from_date or to_date is not a valid date or date-string YYYY-MM-DD.
@@ -105,9 +105,9 @@ class KlassCodes:
         """Change the dates of the codelist and get the data again based on new dates.
 
         Args:
-            from_date (str): The start date of the time period. "YYYY-MM-DD".
-            to_date (str): The end date of the time period. "YYYY-MM-DD".
-            include_future (bool): Whether to include future codes.
+            from_date: The start date of the time period. "YYYY-MM-DD".
+            to_date: The end date of the time period. "YYYY-MM-DD".
+            include_future: Whether to include future codes.
 
         Returns:
             self (KlassSearchFamilies): Returns self to make the method more easily chainable.
@@ -129,7 +129,7 @@ class KlassCodes:
         the date specified by self.from_date.
 
         Args:
-            raise_on_empty_data (bool): Whether to raise an error if the returned dataframe is empty. Defaults to True.
+            raise_on_empty_data: Whether to raise an error if the returned dataframe is empty. Defaults to True.
 
         Returns:
             self (KlassSearchFamilies): Returns self to make the method more easily chainable.
@@ -175,9 +175,9 @@ class KlassCodes:
         If you specify a value for "other", returns a defaultdict instead.
 
         Args:
-            key (str): The name of the column with the values you want as keys.
-            value (str): The name of the column with the values you want as values in your dict.
-            other (str): If key is missing from dict, return this value instead, if you specify an OTHER-value.
+            key: The name of the column with the values you want as keys.
+            value: The name of the column with the values you want as values in your dict.
+            other: If key is missing from dict, return this value instead, if you specify an OTHER-value.
 
         Returns:
             dict | defaultdict: The extracted columns as a dict or defaultdict.
@@ -202,7 +202,7 @@ class KlassCodes:
         First envisioned by @mfmssb
 
         Args:
-            keep (list[str]): The start of the names of the columns you want to keep when done.
+            keep: The start of the names of the columns you want to keep when done.
                 Default is ["code", "name"], but other possibilities are "presentationName",
                 "level", "shortName", "validTo", "validFrom", and "notes".
 

--- a/src/klass/classes/codes.py
+++ b/src/klass/classes/codes.py
@@ -4,8 +4,9 @@ from datetime import datetime
 import pandas as pd
 from typing_extensions import Self
 
-from klass.requests.klass_requests import codes
-from klass.requests.klass_requests import codes_at
+from ..requests.klass_requests import codes
+from ..requests.klass_requests import codes_at
+from ..requests.klass_types import Language
 
 
 class KlassCodes:
@@ -40,13 +41,13 @@ class KlassCodes:
 
     def __init__(
         self,
-        classification_id: str = "",
-        from_date: str = "",
-        to_date: str = "",
-        select_codes: str = "",
-        select_level: int = 0,
-        presentation_name_pattern: str = "",
-        language: str = "nb",
+        classification_id: str | int,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        select_codes: str | None = None,
+        select_level: int | None = None,
+        presentation_name_pattern: str | None = None,
+        language: Language = "nb",
         include_future: bool = False,
     ) -> None:
         """Get the data from the KLASS-api belonging to the code-list."""
@@ -58,7 +59,7 @@ class KlassCodes:
         self.select_codes = select_codes
         self.select_level = select_level
         self.presentation_name_pattern = presentation_name_pattern
-        self.language = language
+        self.language: Language = language
         self.include_future = include_future
         self.get_codes()
 
@@ -97,7 +98,7 @@ class KlassCodes:
 
     def change_dates(
         self,
-        from_date: str = "",
+        from_date: str | None = None,
         to_date: str = "",
         include_future: bool | None = None,
     ) -> Self:
@@ -166,8 +167,8 @@ class KlassCodes:
     def to_dict(
         self,
         key: str = "code",
-        value: str = "",  # default is "name" if not set
-        other: str = "",
+        value: str | None = None,  # default is "name" if not set
+        other: str | None = None,
     ) -> dict[str, str] | defaultdict[str, str]:
         """Extract two columns from the data, turning them into a dict.
 

--- a/src/klass/classes/correspondence.py
+++ b/src/klass/classes/correspondence.py
@@ -37,15 +37,15 @@ class KlassCorrespondence:
         include_future (bool): If the correspondence should include future correspondences.
 
     Args:
-        correspondence_id (str): The ID of the correspondence.
-        source_classification_id (str): The ID of the source classification.
-        target_classification_id (str): The ID of the target classification.
-        from_date (str): The start date of the correspondence.
-        to_date (str, optional): The end date of the correspondence.
-        contain_quarter (int): The number of quarters the correspondence should contain,
+        correspondence_id: The ID of the correspondence.
+        source_classification_id: The ID of the source classification.
+        target_classification_id: The ID of the target classification.
+        from_date: The start date of the correspondence.
+        to_date: The end date of the correspondence.
+        contain_quarter: The number of quarters the correspondence should contain,
             this replaces the to_date during initialization.
-        language (str): The language of the correspondence. "nb", "nn" or "en".
-        include_future (bool): If the correspondence should include future correspondences.
+        language: The language of the correspondence. "nb", "nn" or "en".
+        include_future: If the correspondence should include future correspondences.
     """
 
     @overload
@@ -194,7 +194,10 @@ class KlassCorrespondence:
         Uses the attribute "contain_quarter" to determine which quarter to use.
 
         Returns:
-            str: The last date of the quarter.
+            The last date of the quarter.
+
+        Raises:
+            ValueError: if from date is missing
         """
         if not self.from_date:
             raise ValueError(
@@ -224,9 +227,9 @@ class KlassCorrespondence:
         'targetCode', 'targetName', 'targetShortName', 'validFrom', 'validTo'.
 
         Args:
-            key (str): The name of the column with the values you want as keys.
-            value (str): The name of the column with the values you want as values in your dict.
-            other (str): The value to use for keys that don't exist in the data.
+            key: The name of the column with the values you want as keys.
+            value: The name of the column with the values you want as values in your dict.
+            other: The value to use for keys that don't exist in the data.
             remove_na: Set to False if you want to keep empty mappings over the key and value columns. Empty is defined as empty strings or NA-types.
             select_level: Keep only a specific level defines the variants codes / groups.
 

--- a/src/klass/classes/correspondence.py
+++ b/src/klass/classes/correspondence.py
@@ -5,11 +5,13 @@ from datetime import date
 import dateutil.parser
 import pandas as pd
 from typing_extensions import Self
+from typing_extensions import overload
 
-from klass.requests.klass_requests import correspondence_table_by_id
-from klass.requests.klass_requests import corresponds
-from klass.requests.klass_types import CorrespondsType
-from klass.requests.klass_types import T_correspondanceMaps
+from ..requests.klass_requests import correspondence_table_by_id
+from ..requests.klass_requests import corresponds
+from ..requests.klass_types import CorrespondsType
+from ..requests.klass_types import Language
+from ..requests.klass_types import T_correspondanceMaps
 
 
 class KlassCorrespondence:
@@ -46,15 +48,41 @@ class KlassCorrespondence:
         include_future (bool): If the correspondence should include future correspondences.
     """
 
+    @overload
     def __init__(
-        self,
-        correspondence_id: str = "",
-        source_classification_id: str = "",
-        target_classification_id: str = "",
-        from_date: str = "",
-        to_date: str = "",
+        self: Self,
+        correspondence_id: str | int = ...,
+        source_classification_id: None = ...,
+        target_classification_id: None = ...,
+        from_date: None = ...,
+        to_date: None = ...,
+        contain_quarter: int = ...,
+        language: Language = ...,
+        include_future: bool = ...,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: Self,
+        correspondence_id: None = ...,
+        source_classification_id: str | int = ...,
+        target_classification_id: str | int = ...,
+        from_date: str = ...,
+        to_date: str | None = ...,
+        contain_quarter: int = ...,
+        language: Language = ...,
+        include_future: bool = ...,
+    ) -> None: ...
+
+    def __init__(
+        self: Self,
+        correspondence_id: str | int | None = None,
+        source_classification_id: str | int | None = None,
+        target_classification_id: str | int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
         contain_quarter: int = 0,
-        language: str = "nb",
+        language: Language = "nb",
         include_future: bool = False,
     ) -> None:
         """Get the correspondence-data from the API."""
@@ -64,7 +92,7 @@ class KlassCorrespondence:
         self.from_date = from_date
         self.to_date = to_date
         self.contain_quarter = contain_quarter
-        self.language = language
+        self.language: Language = language
         self.include_future = include_future
 
         self.get_correspondence()
@@ -168,6 +196,10 @@ class KlassCorrespondence:
         Returns:
             str: The last date of the quarter.
         """
+        if not self.from_date:
+            raise ValueError(
+                "Can't calculate the last date of the quarter without from_date"
+            )
         from_date = dateutil.parser.parse(self.from_date)
         year = from_date.year
         last_month_of_quarter = 3 * self.contain_quarter
@@ -180,9 +212,9 @@ class KlassCorrespondence:
         self,
         key: str = "sourceCode",
         value: str = "targetCode",
-        other: str = "",
+        other: str | None = None,
         remove_na: bool = True,
-        select_level: int = 0,
+        select_level: int | None = None,
     ) -> dict[str, str | None] | defaultdict[str, str | None]:
         """Extract two columns from the data, turning them into a dict.
 

--- a/src/klass/classes/family.py
+++ b/src/klass/classes/family.py
@@ -1,7 +1,7 @@
-from klass.classes.classification import KlassClassification
-from klass.requests.klass_requests import classificationfamilies_by_id
-from klass.requests.klass_types import ClassificationFamiliesByIdType
-from klass.requests.klass_types import ClassificationPartWithType
+from ..requests.klass_requests import classificationfamilies_by_id
+from ..requests.klass_types import ClassificationFamiliesByIdType
+from ..requests.klass_types import ClassificationPartWithType
+from .classification import KlassClassification
 
 
 class KlassFamily:
@@ -20,7 +20,7 @@ class KlassFamily:
         family_id (str): The ID of the family.
     """
 
-    def __init__(self, family_id: str) -> None:
+    def __init__(self, family_id: str | int) -> None:
         """Get the family data from the klass-api, setting it as attributes on the object."""
         self.family_id = family_id
         # Setting for mypy
@@ -57,7 +57,9 @@ And contains the following classifications:
         """Representation of the object, and how to recreate it."""
         return f"KlassFamily({self.family_id})"
 
-    def get_classification(self, classification_id: str = "") -> KlassClassification:
+    def get_classification(
+        self, classification_id: str | int | None = None
+    ) -> KlassClassification:
         """Get a classification from the family.
 
         Args:

--- a/src/klass/classes/family.py
+++ b/src/klass/classes/family.py
@@ -17,7 +17,7 @@ class KlassFamily:
         _links (dict): A dictionary of API links referencing itself.
 
     Args:
-        family_id (str): The ID of the family.
+        family_id: The ID of the family.
     """
 
     def __init__(self, family_id: str | int) -> None:
@@ -63,7 +63,7 @@ And contains the following classifications:
         """Get a classification from the family.
 
         Args:
-            classification_id (str): The ID of the classification.
+            classification_id: The ID of the classification.
                 If not given, the first classification in the family is returned based on its ID.
 
         Returns:

--- a/src/klass/classes/search.py
+++ b/src/klass/classes/search.py
@@ -20,10 +20,10 @@ class KlassSearchClassifications:
         no_dupes (bool): Whether to remove duplicates from the search results.
 
     Args:
-        query (str): The search query.
-        include_codelists (bool): Whether to include codelists in the search results.
-        ssbsection (str): The SSB section who owns the classification you are searching for.
-        no_dupes (bool): Whether to remove duplicates from the search results.
+        query: The search query.
+        include_codelists: Whether to include codelists in the search results.
+        ssbsection: The SSB section who owns the classification you are searching for.
+        no_dupes: Whether to remove duplicates from the search results.
             (Usually caused by languages showing up multiple times)
     """
 
@@ -75,8 +75,8 @@ class KlassSearchClassifications:
         """Extract id from each classification, removing dupes.
 
         Args:
-            classifications (list): The classifications to clean.
-            no_dupes (bool): Set to True if you want equal results to be filtered out.
+            classifications: The classifications to clean.
+            no_dupes: Set to True if you want equal results to be filtered out.
 
         Returns:
             list: The cleaned classifications.
@@ -131,10 +131,10 @@ class KlassSearchClassifications:
         """Get a Classification from the search object.
 
         Args:
-            classification_id (str): The classification ID to get.
-            language (str): The language to get the classification in.
+            classification_id: The classification ID to get.
+            language: The language to get the classification in.
                 Default: "nb" for Norwegian, "nn" for Nynorsk, "en" for English.
-            include_future (bool): Whether to include future codelists.
+            include_future: Whether to include future codelists.
 
         Returns:
             KlassClassification: The classification object.
@@ -160,9 +160,9 @@ class KlassSearchFamilies:
     """Search for families in the Klass API.
 
     Args:
-        ssbsection (str): The SSB section who owns the family you are searching for.
-        include_codelists (bool): Whether to include codelists in the search.
-        language (str): The language to use in the search.
+        ssbsection: The SSB section who owns the family you are searching for.
+        include_codelists: Whether to include codelists in the search.
+        language: The language to use in the search.
     Default: "nb" for Norwegian, "nn" for Nynorsk, "en" for English.
     """
 
@@ -234,7 +234,7 @@ class KlassSearchFamilies:
         If no ID is given, chooses the first Family returned by the search.
 
         Args:
-            family_id (str): The family ID to get.
+            family_id: The family ID to get.
 
         Returns:
             KlassFamily: The family object.

--- a/src/klass/classes/search.py
+++ b/src/klass/classes/search.py
@@ -1,11 +1,12 @@
 from typing_extensions import Self
 
-from klass.classes.classification import KlassClassification
-from klass.classes.family import KlassFamily
-from klass.requests.klass_requests import classification_search
-from klass.requests.klass_requests import classificationfamilies
-from klass.requests.klass_types import ClassificationFamiliesPartWithNumberType
-from klass.requests.klass_types import ClassificationSearchResultsPartType
+from ..requests.klass_requests import classification_search
+from ..requests.klass_requests import classificationfamilies
+from ..requests.klass_types import ClassificationFamiliesPartWithNumberType
+from ..requests.klass_types import ClassificationSearchResultsPartType
+from ..requests.klass_types import Language
+from .classification import KlassClassification
+from .family import KlassFamily
 
 
 class KlassSearchClassifications:
@@ -123,7 +124,9 @@ class KlassSearchClassifications:
 
     @staticmethod
     def get_classification(
-        classification_id: str, language: str = "nb", include_future: bool = False
+        classification_id: str | int,
+        language: Language = "nb",
+        include_future: bool = False,
     ) -> KlassClassification:
         """Get a Classification from the search object.
 
@@ -167,7 +170,7 @@ class KlassSearchFamilies:
         self,
         ssbsection: str = "",
         include_codelists: bool = False,
-        language: str = "nb",
+        language: Language = "nb",
     ) -> None:
         """Get data from the KLASS-api, setting it as attributes on this object."""
         self.ssbsection = ssbsection
@@ -225,7 +228,7 @@ class KlassSearchFamilies:
         self.families = families_replace
         return self
 
-    def get_family(self, family_id: str = "0") -> KlassFamily:
+    def get_family(self, family_id: str | int | None = None) -> KlassFamily:
         """Return a KlassFamily object of the family with the given ID.
 
         If no ID is given, chooses the first Family returned by the search.

--- a/src/klass/classes/variant.py
+++ b/src/klass/classes/variant.py
@@ -42,9 +42,9 @@ class KlassVariant:
         _links (dict): The links returned from the API.
 
     Args:
-        variant_id (str): The variant_id of the variant. For example: '1959'.
-        select_level (int): The level of the dataset to keep. For example: 5.
-        language (str): The language of the variant to select. For example: 'nb'.
+        variant_id: The variant_id of the variant. For example: '1959'.
+        select_level: The level of the dataset to keep. For example: 5.
+        language: The language of the variant to select. For example: 'nb'.
     """
 
     def __init__(
@@ -67,7 +67,7 @@ class KlassVariant:
         Other keys are added dynamically to the object, like classificationItems.
 
         Args:
-            select_level (int): The level of the dataset to keep. For example: 0.
+            select_level: The level of the dataset to keep. For example: 0.
         """
         result: VariantsByIdType = variants_by_id(self.variant_id, self.language)
         self.name: str = result["name"]
@@ -185,17 +185,17 @@ class KlassVariantSearchByName(KlassVariant):
         include_future (bool): Whether to include future codes. Defaults to False.
 
     Args:
-        classification_id (str): The classification ID.
-        variant_name (str): The start of the variant name.
-        from_date (str): The start of the date range.
-        to_date (str): The end of the date range.
-        select_codes (str): Limit the result to codes matching this pattern.
+        classification_id: The classification ID.
+        variant_name: The start of the variant name.
+        from_date: The start of the date range.
+        to_date: The end of the date range.
+        select_codes: Limit the result to codes matching this pattern.
             See rules: https://data.ssb.no/api/klass/v1/api-guide.html#_selectcodes
-        select_level (str): The level of codes to keep in the dataset.
-        presentation_name_pattern (str): Used to build an alternative presentation name for the codes.
+        select_level: The level of codes to keep in the dataset.
+        presentation_name_pattern: Used to build an alternative presentation name for the codes.
             See rules: https://data.ssb.no/api/klass/v1/api-guide.html#_presentationnamepattern
-        language (str): Language of the names, select "en", "nb" or "nn".
-        include_future (bool): Whether to include future codes. Defaults to False.
+        language: Language of the names, select "en", "nb" or "nn".
+        include_future: Whether to include future codes. Defaults to False.
     """
 
     def __init__(

--- a/src/klass/classes/variant.py
+++ b/src/klass/classes/variant.py
@@ -2,11 +2,12 @@ from collections import defaultdict
 
 import pandas as pd
 
-from klass.requests.klass_requests import variant
-from klass.requests.klass_requests import variant_at
-from klass.requests.klass_requests import variants_by_id
-from klass.requests.klass_types import CorrespondenceTablesType
-from klass.requests.klass_types import VariantsByIdType
+from ..requests.klass_requests import variant
+from ..requests.klass_requests import variant_at
+from ..requests.klass_requests import variants_by_id
+from ..requests.klass_types import CorrespondenceTablesType
+from ..requests.klass_types import Language
+from ..requests.klass_types import VariantsByIdType
 
 
 class KlassVariant:
@@ -48,14 +49,14 @@ class KlassVariant:
 
     def __init__(
         self,
-        variant_id: str,
-        select_level: int = 0,
-        language: str = "nb",
+        variant_id: str | int,
+        select_level: int | None = None,
+        language: Language = "nb",
     ) -> None:
         """Get the data from the KLASS-api to populate this objects attributes."""
         self.variant_id = variant_id
         self.select_level = select_level
-        self.language = language
+        self.language: Language = language
 
         self.get_variant()
 
@@ -122,9 +123,9 @@ class KlassVariant:
         self,
         key: str = "code",
         value: str = "parentCode",
-        other: str = "",
+        other: str | None = None,
         remove_na: bool = True,
-        select_level: int = 0,
+        select_level: int | None = None,
     ) -> dict[str, str] | defaultdict[str, str]:
         """Extract two columns from the data, turning them into a dict.
 
@@ -199,14 +200,14 @@ class KlassVariantSearchByName(KlassVariant):
 
     def __init__(
         self,
-        classification_id: str,
+        classification_id: str | int,
         variant_name: str,
         from_date: str,
-        to_date: str = "",
-        select_codes: str = "",
-        select_level: int = 0,
-        presentation_name_pattern: str = "",
-        language: str = "nb",
+        to_date: str | None = None,
+        select_codes: str | None = None,
+        select_level: int | None = None,
+        presentation_name_pattern: str | None = None,
+        language: Language = "nb",
         include_future: bool = False,
     ) -> None:
         """Get the data from the KLASS-api, setting it as attributes on the object."""
@@ -221,9 +222,9 @@ class KlassVariantSearchByName(KlassVariant):
         self.include_future = include_future
         self.get_variant()
 
-    def get_variant(self, select_level: int = 0) -> None:
+    def get_variant(self, select_level: int | None = None) -> None:
         """Actually get the data from the API, called at the end of init."""
-        if select_level == 0:
+        if not select_level:
             select_level = self.select_level
 
         if self.to_date:

--- a/src/klass/classes/version.py
+++ b/src/klass/classes/version.py
@@ -32,10 +32,10 @@ class KlassVersion:
         correspondenceTables (list): A list of correspondence-tables of the version.
 
     Args:
-        version_id (str): The ID of the version.
-        select_level (int): The level in the codelist-data to keep. Defaults to 0 (keep all).
-        language (str, optional): The language of the version. Defaults to "nb", can be set to "en", or "nn".
-        include_future (bool, optional): If the version should include future versions. Defaults to False.
+        version_id: The ID of the version.
+        select_level: The level in the codelist-data to keep. Defaults to 0 (keep all).
+        language: The language of the version. Defaults to "nb", can be set to "en", or "nn".
+        include_future: If the version should include future versions. Defaults to False.
     """
 
     def __init__(
@@ -136,7 +136,7 @@ class KlassVersion:
         Run as a part of the class initialization.
 
         Args:
-            select_level (int): The level of the version to keep in the data. Setting to 0 keeps all levels.
+            select_level: The level of the version to keep in the data. Setting to 0 keeps all levels.
 
         Returns:
             self (KlassVersion): Returns self to make the method more easily chainable.
@@ -172,9 +172,9 @@ class KlassVersion:
         """Get a specific variant.
 
         Args:
-            variant_id (str): The ID of the variant.
-            select_level (int): The level of the variant to keep in the data. Setting to 0 keeps all levels.
-            language (str): The language of the variant.
+            variant_id: The ID of the variant.
+            select_level: The level of the variant to keep in the data. Setting to 0 keeps all levels.
+            language: The language of the variant.
 
         Returns:
             KlassVariant: A variant object with the specified ID and language.
@@ -305,14 +305,14 @@ class KlassVersion:
         """Get a specific correspondence.
 
         Args:
-            correspondence_id (str): The ID of the correspondence.
-            source_classification_id (str): The ID of the source classification.
-            target_classification_id (str): The ID of the target classification.
-            from_date (str): The start date of the correspondence.
-            to_date (str): The end date of the correspondence.
-            contain_quarter (int): The number of quarters the correspondence should contain.
-            language (str): The language of the correspondence. "nb", "nn" or "en".
-            include_future (bool): If the correspondence should include future correspondences.
+            correspondence_id: The ID of the correspondence.
+            source_classification_id: The ID of the source classification.
+            target_classification_id: The ID of the target classification.
+            from_date: The start date of the correspondence.
+            to_date: The end date of the correspondence.
+            contain_quarter: The number of quarters the correspondence should contain.
+            language: The language of the correspondence. "nb", "nn" or "en".
+            include_future: If the correspondence should include future correspondences.
 
         Returns:
             KlassCorrespondence: A correspondence object with the specified ID, language, and dates.

--- a/src/klass/classes/version.py
+++ b/src/klass/classes/version.py
@@ -1,12 +1,14 @@
 import pandas as pd
 from typing_extensions import Self
+from typing_extensions import overload
 
-from klass.classes.correspondence import KlassCorrespondence
-from klass.classes.variant import KlassVariant
-from klass.requests.klass_requests import version_by_id
-from klass.requests.klass_types import CorrespondenceTablesType
-from klass.requests.klass_types import VersionByIDType
-from klass.utility.naming import create_shortname
+from ..requests.klass_requests import version_by_id
+from ..requests.klass_types import CorrespondenceTablesType
+from ..requests.klass_types import Language
+from ..requests.klass_types import VersionByIDType
+from ..utility.naming import create_shortname
+from .correspondence import KlassCorrespondence
+from .variant import KlassVariant
 
 
 class KlassVersion:
@@ -38,9 +40,9 @@ class KlassVersion:
 
     def __init__(
         self,
-        version_id: str,
-        select_level: int = 0,
-        language: str = "nb",
+        version_id: str | int,
+        select_level: int | None = None,
+        language: Language = "nb",
         include_future: bool = False,
     ) -> None:
         """Set up the object with data from the KLASS-API."""
@@ -128,7 +130,7 @@ class KlassVersion:
         )
         return result
 
-    def get_classification_codes(self, select_level: int = 0) -> Self:
+    def get_classification_codes(self, select_level: int | None = None) -> Self:
         """Get the codelists of the version. Inserts the result into the KlassVersions .data attribute, instead of returning it.
 
         Run as a part of the class initialization.
@@ -139,8 +141,7 @@ class KlassVersion:
         Returns:
             self (KlassVersion): Returns self to make the method more easily chainable.
         """
-        if not select_level and self.select_level:
-            select_level = self.select_level
+        select_level = select_level if select_level else self.select_level
         data = pd.json_normalize(self.classificationItems)
         level_map = {
             str(item["levelNumber"]): item["levelName"] for item in self.levels
@@ -164,7 +165,9 @@ class KlassVersion:
 
     @staticmethod
     def get_variant(
-        variant_id: str, select_level: int = 0, language: str = "nb"
+        variant_id: str | int,
+        select_level: int | None = None,
+        language: Language = "nb",
     ) -> KlassVariant:
         """Get a specific variant.
 
@@ -263,14 +266,40 @@ class KlassVersion:
         return tables
 
     @staticmethod
+    @overload
     def get_correspondence(
-        correspondence_id: str = "",
-        source_classification_id: str = "",
-        target_classification_id: str = "",
-        from_date: str = "",
-        to_date: str = "",
+        correspondence_id: str | int = ...,
+        source_classification_id: None = ...,
+        target_classification_id: None = ...,
+        from_date: None = ...,
+        to_date: None = ...,
+        contain_quarter: int = ...,
+        language: Language = ...,
+        include_future: bool = ...,
+    ) -> KlassCorrespondence: ...
+
+    @staticmethod
+    @overload
+    def get_correspondence(
+        correspondence_id: None = ...,
+        source_classification_id: str | int = ...,
+        target_classification_id: str | int = ...,
+        from_date: str = ...,
+        to_date: str | None = ...,
+        contain_quarter: int = ...,
+        language: Language = ...,
+        include_future: bool = ...,
+    ) -> KlassCorrespondence: ...
+
+    @staticmethod
+    def get_correspondence(
+        correspondence_id: str | int | None = None,
+        source_classification_id: str | int | None = None,
+        target_classification_id: str | int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
         contain_quarter: int = 0,
-        language: str = "nb",
+        language: Language = "nb",
         include_future: bool = False,
     ) -> KlassCorrespondence:
         """Get a specific correspondence.
@@ -289,15 +318,15 @@ class KlassVersion:
             KlassCorrespondence: A correspondence object with the specified ID, language, and dates.
         """
         return KlassCorrespondence(
-            correspondence_id=correspondence_id,
-            source_classification_id=source_classification_id,
-            target_classification_id=target_classification_id,
-            from_date=from_date,
-            to_date=to_date,
+            correspondence_id=correspondence_id,  # type: ignore [arg-type]
+            source_classification_id=source_classification_id,  # type: ignore [arg-type]
+            target_classification_id=target_classification_id,  # type: ignore [arg-type]
+            from_date=from_date,  # type: ignore [arg-type]
+            to_date=to_date,  # type: ignore [arg-type]
             contain_quarter=contain_quarter,
             language=language,
             include_future=include_future,
-        )
+        )  # type: ignore [misc]
 
     def get_all_correspondences(self) -> list[KlassCorrespondence]:
         """Get all correspondences of version as a list of KlassCorrespondences.

--- a/src/klass/requests/klass_requests.py
+++ b/src/klass/requests/klass_requests.py
@@ -8,20 +8,22 @@ import pandas as pd
 import requests
 from dateutil.parser import ParserError
 
-import klass.config as config
-from klass.requests.klass_types import ClassificationFamiliesByIdType
-from klass.requests.klass_types import ClassificationFamiliesType
-from klass.requests.klass_types import ClassificationsByIdType
-from klass.requests.klass_types import ClassificationSearchType
-from klass.requests.klass_types import ClassificationsType
-from klass.requests.klass_types import CorrespondenceTableIdType
-from klass.requests.klass_types import CorrespondsType
-from klass.requests.klass_types import ParamsAfterType
-from klass.requests.klass_types import ParamsBeforeType
-from klass.requests.klass_types import VariantsByIdType
-from klass.requests.klass_types import VersionByIDType
-from klass.requests.sections import sections_dict
-from klass.requests.validate import validate_params
+from .. import config
+from ..requests.klass_types import ClassificationFamiliesByIdType
+from ..requests.klass_types import ClassificationFamiliesType
+from ..requests.klass_types import ClassificationsByIdType
+from ..requests.klass_types import ClassificationSearchType
+from ..requests.klass_types import ClassificationsType
+from ..requests.klass_types import CorrespondenceTableIdType
+from ..requests.klass_types import CorrespondsType
+from ..requests.klass_types import Language
+from ..requests.klass_types import OptionalLanguage
+from ..requests.klass_types import ParamsAfterType
+from ..requests.klass_types import ParamsBeforeType
+from ..requests.klass_types import VariantsByIdType
+from ..requests.klass_types import VersionByIDType
+from ..requests.sections import sections_dict
+from ..requests.validate import validate_params
 
 # ##########
 # Types #
@@ -132,7 +134,9 @@ def classification_search(
 
 
 def classification_by_id(
-    classification_id: str, language: str = "nb", include_future: bool = False
+    classification_id: str | int,
+    language: Language = "nb",
+    include_future: bool = False,
 ) -> ClassificationsByIdType:
     """Get from the classification-by-id-endpoint."""
     url = config.BASE_URL + URL_PART_CLASS + str(classification_id)
@@ -144,13 +148,13 @@ def classification_by_id(
 
 
 def codes(
-    classification_id: str,
+    classification_id: str | int,
     from_date: str,
-    to_date: str = "",
-    select_codes: str = "",
-    select_level: int = 0,
-    presentation_name_pattern: str = "",
-    language: str = "nb",
+    to_date: str | None = None,
+    select_codes: str | None = None,
+    select_level: int | None = None,
+    presentation_name_pattern: str | None = None,
+    language: OptionalLanguage = "nb",
     include_future: bool = False,
 ) -> pd.DataFrame:
     """Get from the codes-endpoint."""
@@ -176,12 +180,12 @@ def codes(
 
 
 def codes_at(
-    classification_id: str,
+    classification_id: str | int,
     date: str,
-    select_codes: str = "",
-    select_level: int = 0,
-    presentation_name_pattern: str = "",
-    language: str = "nb",
+    select_codes: str | None = None,
+    select_level: int | None = None,
+    presentation_name_pattern: str | None = None,
+    language: OptionalLanguage = "nb",
     include_future: bool = False,
 ) -> pd.DataFrame:
     """Get from the codesAt-endpoint."""
@@ -203,8 +207,8 @@ def codes_at(
 
 
 def version_by_id(
-    version_id: str,
-    language: str = "nb",
+    version_id: str | int,
+    language: Language = "nb",
     include_future: bool = False,
 ) -> VersionByIDType:
     """Get from the version-by-id-endpoint."""
@@ -220,14 +224,14 @@ def version_by_id(
 
 
 def variant(
-    classification_id: str,
+    classification_id: str | int,
     variant_name: str,
     from_date: str,
-    to_date: str = "",
-    select_codes: str = "",
-    select_level: int = 0,
-    presentation_name_pattern: str = "",
-    language: str = "nb",
+    to_date: str | None = None,
+    select_codes: str | None = None,
+    select_level: int | None = None,
+    presentation_name_pattern: str | None = None,
+    language: OptionalLanguage = "nb",
     include_future: bool = False,
 ) -> pd.DataFrame:
     """Get from the variant-endpoint."""
@@ -255,13 +259,13 @@ def variant(
 
 
 def variant_at(
-    classification_id: str,
+    classification_id: str | int,
     variant_name: str,
     date: str,
-    select_codes: str = "",
-    select_level: int = 0,
-    presentation_name_pattern: str = "",
-    language: str = "nb",
+    select_codes: str | None = None,
+    select_level: int | None = None,
+    presentation_name_pattern: str | None = None,
+    language: OptionalLanguage = "nb",
     include_future: bool = False,
 ) -> pd.DataFrame:
     """Get from the variantAt-endpoint."""
@@ -287,7 +291,9 @@ def variant_at(
     return result
 
 
-def variants_by_id(variant_id: str, language: str = "nb") -> VariantsByIdType:
+def variants_by_id(
+    variant_id: str | int, language: Language = "nb"
+) -> VariantsByIdType:
     """Get from the variants-endpoint."""
     url = config.BASE_URL + "variants/" + str(variant_id)
     params: ParamsAfterType = validate_params({"language": language})
@@ -296,11 +302,11 @@ def variants_by_id(variant_id: str, language: str = "nb") -> VariantsByIdType:
 
 
 def corresponds(
-    source_classification_id: str,
-    target_classification_id: str,
+    source_classification_id: str | int,
+    target_classification_id: str | int,
     from_date: str,
-    to_date: str = "",
-    language: str = "nb",
+    to_date: str | None = None,
+    language: OptionalLanguage = "nb",
     include_future: bool = False,
 ) -> CorrespondsType:
     """Get from the classifications/corresponds-endpoint."""
@@ -327,10 +333,10 @@ def corresponds(
 
 
 def corresponds_at(
-    source_classification_id: str,
-    target_classification_id: str,
+    source_classification_id: str | int,
+    target_classification_id: str | int,
     date: str,
-    language: str = "nb",
+    language: OptionalLanguage = "nb",
     include_future: bool = False,
 ) -> CorrespondsType:
     """Get from the classificatins/correspondsAt-endpoint."""
@@ -355,8 +361,8 @@ def corresponds_at(
 
 
 def correspondence_table_by_id(
-    correspondence_id: str,
-    language: str = "nb",
+    correspondence_id: str | int,
+    language: Language = "nb",
 ) -> CorrespondenceTableIdType:
     """Get from the correspondence-table-by-id-endpoint."""
     url = config.BASE_URL + "correspondencetables/" + str(correspondence_id)
@@ -366,10 +372,10 @@ def correspondence_table_by_id(
 
 
 def changes(
-    classification_id: str,
+    classification_id: str | int,
     from_date: str,
-    to_date: str = "",
-    language: str = "nb",
+    to_date: str | None = None,
+    language: OptionalLanguage = "nb",
     include_future: bool = False,
 ) -> pd.DataFrame:
     """Get from the classifications/changes-endpoint."""
@@ -392,9 +398,9 @@ def changes(
 
 
 def classificationfamilies(
-    ssbsection: str = "",
+    ssbsection: str | None = None,
     include_codelists: bool = False,
-    language: str = "nb",
+    language: Language = "nb",
 ) -> ClassificationFamiliesType:
     """Get from the classificationfamilies-endpoint."""
     url = config.BASE_URL + "classificationfamilies"
@@ -410,10 +416,10 @@ def classificationfamilies(
 
 
 def classificationfamilies_by_id(
-    classificationfamily_id: str,
-    ssbsection: str = "",
+    classificationfamily_id: str | int,
+    ssbsection: str | None = None,
     include_codelists: bool = False,
-    language: str = "nb",
+    language: Language = "nb",
 ) -> ClassificationFamiliesByIdType:
     """Get from the classificationsfamilies-endpoint with id."""
     url = config.BASE_URL + "classificationfamilies/" + str(classificationfamily_id)

--- a/src/klass/requests/klass_types.py
+++ b/src/klass/requests/klass_types.py
@@ -1,6 +1,11 @@
-from typing import TypedDict
+from typing import Literal
+from typing import TypeAlias
 
 from typing_extensions import NotRequired
+from typing_extensions import TypedDict
+
+Language: TypeAlias = Literal["nb", "nn", "en"]
+OptionalLanguage: TypeAlias = Language | Literal[""] | None
 
 # Keeping these two as non-class, declarative, as the API operates with the parameter "from", which is a reserved keyword in Python
 ParamsBeforeType = TypedDict(
@@ -15,7 +20,7 @@ ParamsBeforeType = TypedDict(
         "selectLevel": NotRequired[str],
         "presentationNamePattern": NotRequired[str],
         "variantName": NotRequired[str],
-        "targetClassificationId": NotRequired[str],
+        "targetClassificationId": NotRequired[str | int],
         "ssbSection": NotRequired[str],
         "includeCodelists": NotRequired[bool],  # Will be converted to lowercase string
         "changedSince": NotRequired[str],
@@ -25,7 +30,7 @@ ParamsBeforeType = TypedDict(
 ParamsAfterType = TypedDict(
     "ParamsAfterType",
     {
-        "language": NotRequired[str],
+        "language": NotRequired[Language],
         "includeFuture": NotRequired[str],
         "from": NotRequired[str],  # Cant convert to class cause of this thingy
         "to": NotRequired[str],
@@ -116,7 +121,7 @@ class ClassificationsByIdType(TypedDict):
     classificationType: str
     lastModified: str
     description: str
-    primaryLanguage: str
+    primaryLanguage: Language | Literal[""]
     copyrighted: bool
     includeShortName: bool
     includeNotes: bool

--- a/src/klass/utility/classification.py
+++ b/src/klass/utility/classification.py
@@ -1,6 +1,6 @@
 from klass.classes.classification import KlassClassification
 
 
-def get_classification(classification_id: str) -> KlassClassification:
+def get_classification(classification_id: str | int) -> KlassClassification:
     """Use this simple factory-function to create instances of KlassClassifications (classes are scary)."""
     return KlassClassification(classification_id)

--- a/src/klass/utility/codes.py
+++ b/src/klass/utility/codes.py
@@ -4,7 +4,7 @@ from klass.classes.codes import KlassCodes
 
 
 def get_codes(
-    classification_id: str = "", date: str = "", dataframe: bool = False
+    classification_id: str | int, date: str | None = None, dataframe: bool = False
 ) -> KlassCodes | pd.DataFrame:
     """Get the codelist-data from a classification as a dataframe, or a KlassCodes-wrapper (includes metadata)."""
     if dataframe:


### PR DESCRIPTION
ssb-klass-python klass takler både `int` og `str` som classification_id, gjennomgående i alle metoder og funksjoner. Så da er det rart typehintene sier noe annet. Har masse eksisterende kode som kaller klass-APIet med int. Hvis ssb-klass-python skulle slutte å støtte `int` i framtiden, vil jeg anse det som en "breaking-change".
Derfor er det bedre at støtten for dette er dokumentert i typehintene.
Har også lagt til en `Literal` type for språkkoder.