### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/statisticsnorway/ssb-klass-python/security/code-scanning/3](https://github.com/statisticsnorway/ssb-klass-python/security/code-scanning/3)

The best fix is to specify a `permissions` block to restrict the `GITHUB_TOKEN` permissions for this workflow. Because both jobs (`tests` and `coverage`) do not seem to require any write access to repository contents or administrative operations, we should set their permissions to read-only for `contents`. We can do this by adding the following block either at the rooting level (applies to all jobs) or at individual job levels. For clarity and future extensibility, the workflow-level block is preferred as a starting point; further job-level overrides can then be added if any job needs write access (e.g., to pull requests or specific artifacts). 

Edit `.github/workflows/tests.yml`. At the top, immediately after the `name: Tests` line—and before the `on:` trigger—add:

```yaml
permissions:
  contents: read
```

This restricts all jobs in the workflow to only read-access to repository contents by default. You may adjust granular permissions later if pull-requests, issues, or other tokens needing write are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
